### PR TITLE
RHMAP-10383 Using standalone-openshift.xml instead of standalone.xml

### DIFF
--- a/eap/Dockerfile
+++ b/eap/Dockerfile
@@ -16,19 +16,6 @@ RUN wget -O mysql-connector-java-5.1.18.jar http://search.maven.org/remoteconten
 RUN mv mysql-connector-java-5.1.18.jar ${mysql_module_dir}
 COPY configuration/xml/mysql-module.xml ${mysql_module_dir}/module.xml
 
-## modules for json logging
-ENV logmanager_module_dir=$JBOSS_HOME/modules/org/jboss/logmanager/ext/main/
-RUN mkdir -p ${logmanager_module_dir}
-RUN wget -O jboss-logmanager-ext.jar https://repository.jboss.org/nexus/service/local/repositories/releases/content/org/jboss/logmanager/jboss-logmanager-ext/1.0.0.Alpha3/jboss-logmanager-ext-1.0.0.Alpha3.jar
-RUN mv jboss-logmanager-ext.jar ${logmanager_module_dir}
-COPY configuration/xml/logmanager-module.xml ${logmanager_module_dir}/module.xml
-
-ENV jsonp_module_dir=$JBOSS_HOME/modules/javax/json/api/main/
-RUN mkdir -p ${jsonp_module_dir}
-RUN wget -O javax.json.jar http://search.maven.org/remotecontent?filepath=org/glassfish/javax.json/1.0.4/javax.json-1.0.4.jar
-RUN mv javax.json.jar ${jsonp_module_dir}
-COPY configuration/xml/jsonp-module.xml ${jsonp_module_dir}/module.xml
-
 # Rename the original configuration file
 RUN mv $JBOSS_HOME/standalone/configuration/standalone.xml $JBOSS_HOME/standalone/configuration/standalone.xml.orig
 

--- a/eap/configuration/xml/standalone-full-sample.xml
+++ b/eap/configuration/xml/standalone-full-sample.xml
@@ -100,7 +100,7 @@
         <subsystem xmlns="urn:jboss:domain:logging:1.5">
             <console-handler name="RESTEASY">
                 <formatter>
-                    <named-formatter name="JSON"/>
+                    <named-formatter name="OPENSHIFT"/>
                 </formatter>
             </console-handler>
             <logger category="org.jboss.resteasy" use-parent-handlers="false">
@@ -109,20 +109,19 @@
                     <handler name="RESTEASY"/>
                 </handlers>
             </logger>
+            <async-handler name="ASYNC">
+                <queue-length value="512"/>
+                <overflow-action value="block"/>
+                <subhandlers>
+                    <handler name="CONSOLE"/>
+                </subhandlers>
+            </async-handler>
             <console-handler name="CONSOLE">
                 <level name="INFO"/>
                 <formatter>
-                    <named-formatter name="JSON"/>
+                    <named-formatter name="OPENSHIFT"/>
                 </formatter>
             </console-handler>
-            <periodic-rotating-file-handler name="FILE" autoflush="true">
-                <formatter>
-                    <named-formatter name="JSON"/>
-                </formatter>
-                <file relative-to="jboss.server.log.dir" path="server.log"/>
-                <suffix value=".yyyy-MM-dd"/>
-                <append value="true"/>
-            </periodic-rotating-file-handler>
             <logger category="org.jboss.weld.Bean">
                 <level name="ERROR"/>
             </logger>
@@ -147,12 +146,18 @@
             <root-logger>
                 <level name="INFO"/>
                 <handlers>
-                    <handler name="CONSOLE"/>
-                    <handler name="FILE"/>
+                    <handler name="ASYNC"/>
                 </handlers>
             </root-logger>
-            <formatter name="JSON">
-                <custom-formatter module="org.jboss.logmanager.ext" class="org.jboss.logmanager.ext.formatters.JsonFormatter"/>
+            <formatter name="OPENSHIFT">
+                <custom-formatter module="org.jboss.logmanager.ext" class="org.jboss.logmanager.ext.formatters.LogstashFormatter">
+                    <properties>
+                        <property name="metaData" value="log-handler=CONSOLE"/>
+                    </properties>
+                </custom-formatter>
+            </formatter>
+            <formatter name="COLOR-PATTERN">
+                <pattern-formatter pattern="%K{level}%d{HH:mm:ss,SSS} %-5p [%c] (%t) %s%E%n"/>
             </formatter>
         </subsystem>
         <subsystem xmlns="urn:jboss:domain:cmp:1.1"/>

--- a/eap/unifiedpush-eap/entrypoint.sh
+++ b/eap/unifiedpush-eap/entrypoint.sh
@@ -14,5 +14,12 @@ echo "Starting Liquibase migration"
 cd $UPSDIST/migrator/
 ./bin/ups-migrator update
 
+LOGGING_FILE=$JBOSS_HOME/standalone/configuration/logging.properties
+
+. $JBOSS_HOME/bin/launch/json_logging.sh
+configure_json_logging
+
+echo "Running $JBOSS_IMAGE_NAME image, version $JBOSS_IMAGE_VERSION-$JBOSS_IMAGE_RELEASE"
+
 # launch eap
 exec $JBOSS_HOME/bin/standalone.sh -b 0.0.0.0 $@


### PR DESCRIPTION
# Motivation

The UPS upstream standalone-openshift.xml file is already set up for logging to JSON. It's better to use this instead.

# Changes

Updated standalone-openshift.xml template file with params from the upstream.
Reverted previous JSON logging configuration.