### PR TITLE
Override APNS/FCM host using env var

### DIFF
--- a/eap/configuration/xml/standalone-full-sample.xml
+++ b/eap/configuration/xml/standalone-full-sample.xml
@@ -46,6 +46,8 @@
         <property name="aerogear.windows_wns.batchesToLoad" value="10"/>
         <property name="aerogear.windows_mpns.batchSize" value="1000"/>
         <property name="aerogear.windows_mpns.batchesToLoad" value="10"/>
+        <property name="aerogear.apns.push.host" value="${env.APNS_PUSH_HOST}"/>
+        <property name="aerogear.fcm.push.host" value="${env.FCM_PUSH_HOST}"/>
     </system-properties>
     <management>
         <security-realms>


### PR DESCRIPTION
We want to set this options using OSCP environment variables.