### PR TITLE
Explicitly setting latest tag in eap Dockerfile

### DIFF
--- a/eap/unifiedpush-eap/Dockerfile
+++ b/eap/unifiedpush-eap/Dockerfile
@@ -1,5 +1,5 @@
 # Use latest rhmap/eap image as the base
-FROM rhmap/eap
+FROM rhmap/eap:latest
 
 RUN mkdir -p $JBOSS_HOME/standalone/data && \
     mkdir -p $JBOSS_HOME/standalone/tmp/vfs/temp && \


### PR DESCRIPTION
**Summary**
Explicitly setting latest tag for rhmap/eap image in unified-push eap Dockerfile