### PR TITLE
Make FROM image more explicit

### DIFF
--- a/eap/unifiedpush-eap/Dockerfile
+++ b/eap/unifiedpush-eap/Dockerfile
@@ -1,5 +1,5 @@
 # Use latest rhmap/eap image as the base
-FROM rhmap/eap:latest
+FROM docker.io/rhmap/eap:latest
 
 RUN mkdir -p $JBOSS_HOME/standalone/data && \
     mkdir -p $JBOSS_HOME/standalone/tmp/vfs/temp && \


### PR DESCRIPTION
This appears to be needed when building on RHEL/OpenShift, since the
default registry is registry.access.redhat.com. On our Wendy build
server, we don't have credentials for that registry, so we get the
following error:

failed to pull image: unauthorized: authentication required